### PR TITLE
Corrects the extension to reflect the behaviour of nameWithoutExtension

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -33,7 +33,7 @@ class File(private[this] val _path: Path) {
   /**
    * @return extension (including the dot) of this file if it is a regular file and has an extension, else None
    */
-  def extension: Option[String] = when(hasExtension)(name.substring(name indexOf ".").toLowerCase)
+  def extension: Option[String] = when(hasExtension)(name.substring(name lastIndexOf ".").toLowerCase)
 
   def hasExtension: Boolean = isRegularFile && (name contains ".")
 


### PR DESCRIPTION
on filenames like "example.scala.html" nameWithoutExtension returns "example.scala" but extension returned .scala.html instead of only .html this PR corrects it.

(imho the extension of a filename should be the part AFTER the last '.' so in the example it should be 'html' but that's another discussion)