### PR TITLE
fixed relative globbing

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -237,7 +237,7 @@ class File(private[this] val _path: Path) {
   def glob(pattern: String, syntax: String = "glob", ignoreIOExceptions: Boolean = false): Files = {
     val matcher = fileSystem.getPathMatcher(s"$syntax:$pattern")
     //TODO: In Scala 2.11 SAM: Files.walk(path).filter(matcher.matches(_))
-    Files.walk(path).filter(new java.util.function.Predicate[Path] {override def test(path: Path) = matcher matches path})
+    Files.walk(path).filter(new java.util.function.Predicate[Path] {override def test(path: Path) = matcher matches _path.relativize(path)})
   }
 
   def fileSystem: FileSystem = path.getFileSystem


### PR DESCRIPTION
b-f should also allow for relative globbing to be consistent with the reference
http://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob
which indicates that the following should be possible:
```
val logDir = File("/Users/brandl/Desktop/some_files")
logDir.list
logDir.glob("*.log")
```