### PR TITLE
Auto-closing for java streams returned by `list`

### DIFF
--- a/core/src/main/scala/better/files/AutoClosingStream.scala
+++ b/core/src/main/scala/better/files/AutoClosingStream.scala
@@ -17,7 +17,9 @@ object AutoClosingStream {
     def get: Option[File] = {
       streamIterator.hasNext match {
         case true => Some(new File(streamIterator.next))
-        case false => None
+        case false =>
+          jstream.close
+          None
       }
     }
     

--- a/core/src/main/scala/better/files/AutoClosingStream.scala
+++ b/core/src/main/scala/better/files/AutoClosingStream.scala
@@ -1,0 +1,26 @@
+package better.files
+import java.util.stream.{Stream => JStream}
+
+/*
+ * Provides an iterator that auto-closes the underlying java
+ * stream, to avoid leaking open file descriptors.
+ * 
+ * If the stream is not depleted, it will not auto-close.
+ *  
+ */
+object AutoClosingStream {
+  
+  def apply(jstream: JStream[java.nio.file.Path]): Iterator[File] = {
+    
+    val streamIterator = jstream.iterator
+  
+    def get: Option[File] = {
+      streamIterator.hasNext match {
+        case true => Some(new File(streamIterator.next))
+        case false => None
+      }
+    }
+    
+    Iterator.continually(get).takeWhile(_.isDefined).map(_.get)
+  }
+}

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -233,9 +233,9 @@ class File(private[this] val _path: Path) {
 
   def isHidden: Boolean = Files.isHidden(path)
 
-  def list: Files = Files.list(path)
-  def children: Files = list
-  def entries: Files = list
+  def list = AutoClosingStream(Files.list(path))
+  def children = list
+  def entries = list
 
   def listRecursively(implicit visitOptions: File.VisitOptions = File.VisitOptions.default): Files = walk()(visitOptions).filterNot(isSamePathAs)
 
@@ -454,8 +454,8 @@ class File(private[this] val _path: Path) {
    * @return The destination zip file
    */
   def zipTo(destination: File, compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(implicit codec: Codec): File = {
-    val files = if (isDirectory) children.toSeq else Seq(this)
-    Cmds.zip(files: _*)(destination, compressionLevel)(codec)
+    val files = if (isDirectory) children else Iterator(this)
+    Cmds.zip(files.toSeq: _*)(destination, compressionLevel)(codec)
   }
 
   /**

--- a/core/src/main/scala/better/files/Implicits.scala
+++ b/core/src/main/scala/better/files/Implicits.scala
@@ -116,8 +116,9 @@ trait Implicits {
   implicit class CloseableOps[A <: Closeable](resource: A) {
     import scala.language.reflectiveCalls
     /**
-     * Lightweight automatic resource management
-     * Closes the resource when done
+     * Overrides `foreach` such that it closes the resource
+     * when done, or if an exception occurs.
+		 *
      * e.g.
      * <pre>
      * for {
@@ -126,6 +127,8 @@ trait Implicits {
      * // in is closed now
      * </pre>
      * @return
+     * 
+     * FIXME: there is no reason to swallow all exceptions here.
      */
     def autoClosed: ManagedResource[A] = new Traversable[A] {
       override def foreach[U](f: A => U) = try {
@@ -136,7 +139,9 @@ trait Implicits {
     }
 
     /**
-     * Utility to make a closeable an iterator (auto close when done)
+     * Provides and iterator that closes the underlying resource
+     * when done.
+     * 
      * e.g.
      * <pre>
      * inputStream.autoClosedIterator(_.read())(_ != -1).map(_.toByte)


### PR DESCRIPTION
This solves https://gitter.im/pathikrit/better-files?at=569abd3e2bc35f6c1c1a7de4 as much as the other auto-closing methods do so for byte stream reading. Being unable to close the streams is really a blocking issue for any scenario that runs a lot of the `list` api of this library.  

Please have a look at it and apply some judgement, I put this together in a hurry.

