### PR TITLE
Added parameters to extension method (#35)

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -31,7 +31,18 @@ class File private (val path: Path) { //TODO: LinkOption?
   /**
    * @return extension (including the dot) of this file if it is a regular file and has an extension, else None
    */
-  def extension: Option[String] = when(hasExtension)(name.substring(name lastIndexOf ".").toLowerCase)
+  def extension: Option[String] = extension(includeDot = true, includeAll = false)
+
+  /**
+   * @param includeDot whether the dot should be included in the extension or not
+   * @param includeAll whether all extension tokens should be included, or just the last one
+   * @return extension of this file if it is a regular file and has an extension, else None
+   */
+  def extension(includeDot: Boolean = true, includeAll: Boolean = false): Option[String] = when(hasExtension){
+    val dot = if (includeAll) name indexOf "." else name lastIndexOf "."
+    val index = if (includeDot) dot else dot + 1
+    name.substring(index).toLowerCase
+  }
 
   def hasExtension: Boolean = (isRegularFile || notExists) && (name contains ".")
 

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -21,6 +21,7 @@ class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
   var a2: File = _
   var t1: File = _
   var t2: File = _
+  var t3: File = _
   var fb: File = _
   var b1: File = _
   var b2: File = _
@@ -44,6 +45,7 @@ class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
     a2 = testRoot/"a"/"a2"
     t1 = testRoot/"a"/"a1"/"t1.txt"
     t2 = testRoot/"a"/"a1"/"t2.txt"
+    t3 = testRoot/"a"/"a1"/"t3.scala.txt"
     fb = testRoot/"b"
     b1 = testRoot/"b"/"b1"
     b2 = testRoot/"b"/"b2.txt"
@@ -144,6 +146,10 @@ class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
     fa.extension shouldBe None
     fa.nameWithoutExtension shouldBe fa.name
     t1.extension shouldBe Some(".txt")
+    t1.extension(includeDot = false) shouldBe Some("txt")
+    t3.extension shouldBe Some(".txt")
+    t3.extension(includeAll = true) shouldBe Some(".scala.txt")
+    t3.extension(includeDot = false, includeAll = true) shouldBe Some("scala.txt")
     t1.name shouldBe "t1.txt"
     t1.nameWithoutExtension shouldBe "t1"
     t1.changeExtensionTo(".md").name shouldBe "t1.md"


### PR DESCRIPTION
- can return extension with/without dot
- can return all or just the last extension token

Needed to override extension to not break existing code (default parameters would necessitate all calls to have parentheses).
I've made includeAll default to false since I feel like it's the more intuitive default behaviour.