### PR TITLE
swap normalize and toAbsolutePath in File ctor

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -549,7 +549,7 @@ object File {
       case _ => Files.createTempFile(prefix, suffix, attributes: _*)
     }
 
-  implicit def apply(path: Path): File = new File(path.normalize().toAbsolutePath)
+  implicit def apply(path: Path): File = new File(path.toAbsolutePath().normalize())
 
   def apply(path: String, fragments: String*): File = Paths.get(path, fragments: _*)
 

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -76,6 +76,10 @@ class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
     val f7: File = home/"Documents"/"presentations"/`..`         // Use `..` to navigate up to parent
     val f8: File = root/"User"/"johndoe"/"Documents"/ `.`
     val f9: File = File(f.uri)
+    val f10: File = File("../a")                                 // using a relative path
+    List(f,f1,f2,f3,f4,/* f5,*/f6,f7,f8,f9,f10).foreach { f =>
+      f.pathAsString should not include("..")
+    }
 
     root.toString shouldEqual "/"
     home.toString.count(_ == '/') should be > 1


### PR DESCRIPTION
When instantiating File with a relative path, first normalizing and then
making it absolute results in an unnormalized path: File("../a") ==
File("/abso/lute/../a"). Normalizing after making the path absolute,
creates an absolute normalized path.

Since other cases (like `File("a/../a/b")` -> `File("a/b")`) create normalized paths, I thought this should too.
WDYT?