### PR TITLE
Added implicit visitoptions to glob and collectChildren

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -346,17 +346,21 @@ class File private (val path: Path) { //TODO: LinkOption?
    * Util to glob from this file's path
    * @return Set of files that matched
    */
-  def glob(pattern: String)(implicit syntax: File.PathMatcherSyntax = File.PathMatcherSyntax.default): Files = {
+  def glob(pattern: String)(implicit syntax: File.PathMatcherSyntax = File.PathMatcherSyntax.default, visitOptions: File.VisitOptions = File.VisitOptions.default): Files = {
     val matcher = pathMatcher(syntax)(pattern)
-    collectChildren(child => matcher.matches(child.path))
+    collectChildren(child => matcher.matches(child.path))(visitOptions)
   }
 
   /**
    * More Scala friendly way of doing Files.walk
-   * @param filter
+ *
+   * @param matchFilter
    * @return
    */
-  def collectChildren(filter: File => Boolean): Files = Files.walk(path).filter(new java.util.function.Predicate[Path] {override def test(path: Path) = filter(path)}) //TODO: In Scala 2.11 SAM: Files.walk(path).filter(f(_))
+  def collectChildren(matchFilter: File => Boolean)(implicit visitOptions: File.VisitOptions = File.VisitOptions.default): Files = {
+    walk()(visitOptions).filter(matchFilter(_))
+    //TODO: In Scala 2.11 SAM: Files.walk(path).filter(f(_))
+  }
 
   def fileSystem: FileSystem = path.getFileSystem
 


### PR DESCRIPTION
The PR allows to use `glob` also when symbolic links are involved.

Do you know why the NIO API designers decided to not follow links by default? It's in contrary with the way linux works, where the user always has to indicate if she does NOT want to follow them. For sure it's nothing _bf_ can/should fix, I'm just curious.

IMHO `collectChildren()` and `pathMatcher()` just bloat the API and could be inlined to keep things simple. They do not add much value and `glob` is their only usage. 


