### PR TITLE
Fix creating hard links.

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -660,7 +660,7 @@ class File private(val path: Path) {
 
   def linkTo(destination: File, symbolic: Boolean = false)(implicit attributes: File.Attributes = File.Attributes.default): destination.type = {
     if (symbolic) symbolicLinkTo(destination)(attributes) else {
-      Files.createLink(path, destination.path)
+      Files.createLink(destination.path, path)
       destination
     }
   }

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -12,6 +12,7 @@ import scala.util.Try
 
 class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
   val isCI = sys.env.get("CI").exists(_.toBoolean)
+  val isUnixOS = Seq("Linux", "MacOS").contains(System.getProperty("os.name", "Other"))
 
   def sleep(t: FiniteDuration = 2 second) = Thread.sleep(t.toMillis)
 
@@ -286,6 +287,14 @@ class FileSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
     t3 moveTo t2
     t2.exists shouldBe true
     t3.exists shouldBe false
+  }
+
+  it should "support creating hard links with ln" in {
+    assume(isUnixOS)
+    val magicWord = "Hello World"
+    t1 writeText magicWord
+    t1.linkTo(t3, symbolic = false)
+    (a1 / "t3.scala.txt").contentAsString shouldEqual magicWord
   }
 
   it should "support custom codec" in {


### PR DESCRIPTION
_java.nio.File.createLink_ takes the destination path first, not second ... rather unintuitively.
Feel free to clean up the test a bit, I'm using _t3_ as the link target because the file is not created/touched during test setup, yet I didn't fully grasp the meaning/distinction of the _a/b/t_ test files.