### PR TITLE
Don't load entire file to memory while calculating checksum

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -1,6 +1,5 @@
 package better.files
 
-
 import java.io.{File => JFile, FileSystem => JFileSystem, _} //TODO: Scala 2.10 does not like java.io._
 import java.net.URI
 import java.nio.channels.{OverlappingFileLockException, AsynchronousFileChannel, FileChannel, NonWritableChannelException, NonReadableChannelException}
@@ -375,9 +374,8 @@ class File private(val path: Path) {
         val bytes = relativePath.toString.getBytes
         algorithm.update(bytes)
       } else {
-        file.inputStream foreach { stream =>
-          val digestStream = new DigestInputStream(stream, algorithm)
-          while (digestStream.read() != -1) {}
+        file.bytes.grouped(1024) foreach { bytes =>
+          algorithm.update(bytes.toArray)
         }
       }
     }

--- a/core/src/main/scala/better/files/Implicits.scala
+++ b/core/src/main/scala/better/files/Implicits.scala
@@ -11,6 +11,7 @@ import java.util.zip.{Deflater, GZIPInputStream, ZipEntry, ZipOutputStream, GZIP
 
 import scala.annotation.tailrec
 import scala.io.{BufferedSource, Codec, Source}
+import scala.util.control.NonFatal
 
 /**
   * Container for various implicits
@@ -212,9 +213,13 @@ trait Implicits {
       }
 
       def next() = try {
-        generator(resource)
-      } finally {
-        close()
+        val next = generator(resource)
+        if (!isValidElement(next)) close()
+        next
+      } catch {
+        case NonFatal(ex) =>
+          close()
+          throw ex
       }
 
       Iterator.continually(next()).takeWhile(isOpen)


### PR DESCRIPTION
File.digest tries to load entire file to memory, which can become a reason of memory overload and application crashing with "GC overhead limit exceeds".
I suggest to use DigestInputStream for calculating hash codes in a streaming manner to avoid this.