### PR TITLE
Create unique directory/unique file helper (Issue #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,8 @@ Creating a unique directory or file is easy:
 import better.files._
 import File._
 
-unique //res0: better.files.File = /path/to/current/dir/73372518-1625-4953-89f5-f3a63a7faed1
-unique/"file.jpg" // /path/to/current/dir/302aa9d3-cab3-4411-b0cd-0c8ce376729b/file.jpg
-home / unique.pathAsString // /home/user/11268b08-2cca-4abe-9d10-236f9283cf33
+newUniqueFile() //res0: better.files.File = /path/to/current/dir/73372518-1625-4953-89f5-f3a63a7faed1
+newUniqueDirectory() //res0: better.files.File = /path/to/current/dir/bb0d7569-d6a0-43e3-8422-9a481cf9c51d/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ import better.files._
 import java.io.{File => JFile}
 ```
 
+Creating a unique directory or file is easy:
+```scala
+import better.files._
+import File._
+
+unique //res0: better.files.File = /path/to/current/dir/73372518-1625-4953-89f5-f3a63a7faed1
+unique/"file.jpg" // /path/to/current/dir/302aa9d3-cab3-4411-b0cd-0c8ce376729b/file.jpg
+home / unique.pathAsString // /home/user/11268b08-2cca-4abe-9d10-236f9283cf33
+```
+
+
 ### File Read/Write
 Dead simple I/O:
 ```scala

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -6,6 +6,7 @@ import java.nio.channels.{OverlappingFileLockException, AsynchronousFileChannel,
 import java.nio.file._, attribute._
 import java.security.{MessageDigest, DigestInputStream}
 import java.time.Instant
+import java.util.UUID
 import java.util.zip.{Deflater, ZipFile}
 import javax.xml.bind.DatatypeConverter
 
@@ -828,6 +829,9 @@ object File {
 
   def currentWorkingDirectory: File =
     File("")
+
+  def unique: File =
+    File(UUID.randomUUID().toString)
 
   type Attributes = Seq[FileAttribute[_]]
   object Attributes {

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -833,6 +833,10 @@ object File {
   def newUniqueFile(): File =
     File(UUID.randomUUID().toString)
 
+  def newUniqueDirectory(): File =
+    newUniqueFile.createDirectory()
+
+
   type Attributes = Seq[FileAttribute[_]]
   object Attributes {
     val default   : Attributes = Seq.empty

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -830,7 +830,7 @@ object File {
   def currentWorkingDirectory: File =
     File("")
 
-  def unique: File =
+  def unique(): File =
     File(UUID.randomUUID().toString)
 
   type Attributes = Seq[FileAttribute[_]]

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -830,7 +830,7 @@ object File {
   def currentWorkingDirectory: File =
     File("")
 
-  def unique(): File =
+  def newUniqueFile(): File =
     File(UUID.randomUUID().toString)
 
   type Attributes = Seq[FileAttribute[_]]


### PR DESCRIPTION
UUID's from Java are unique across time and space so I believe it
satisfies the feature opened on the github repo in #32 

Updated the README to show how to use it. 

I'm not really sure how I'd write a test for this though, because it 
is using UUID's to generate the file name, which _should_ be 
sufficiently unique I believe. 
