### PR TITLE
Unzip even if parent entry not exist

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -780,7 +780,7 @@ class File private(val path: Path) {
     for {
       zipFile <- new ZipFile(toJava, codec).autoClosed
       entry <- zipFile.entries().asScala
-      file = destination.createChild(entry.getName, entry.isDirectory)
+      file = (destination / entry.getName).createIfNotExists(entry.isDirectory, createParents = true)
       if !entry.isDirectory
     } zipFile.getInputStream(entry) > file.newOutputStream
     destination


### PR DESCRIPTION
For a zip with entries like this:
```
$ unzip -l a.zip 
Archive:  a.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        5  2017-01-14 14:28   a/c
        5  2017-01-14 14:28   a/b
---------                     -------
       10                     2 files
```
Using unzip can successfully extract it
```
$ unzip a.zip 
Archive:  a.zip
 extracting: a/c                     
 extracting: a/b
$ tree a/
a/
├── b
└── c
```
But better-files' `unzipTo` will fail to unzip it since it's missing the parent entry `a/`.
This PR tried to fix it by using `createIfNotExists` with `createParents = true`.