### PR TITLE
escapePath was not properly escaping backslashes in Windows paths

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -1036,7 +1036,7 @@ object File {
   object PathMatcherSyntax {
     val glob: PathMatcherSyntax = new PathMatcherSyntax("glob") {
       override def escapePath(path: String) = path
-        .replaceAllLiterally("""\\""", """\\\\""")
+        .replaceAllLiterally("\\", "\\\\")
         .replaceAllLiterally("*", "\\*")
         .replaceAllLiterally("?", "\\?")
         .replaceAllLiterally("{", "\\{")

--- a/core/src/test/scala/better/files/GlobSpec.scala
+++ b/core/src/test/scala/better/files/GlobSpec.scala
@@ -80,16 +80,19 @@ class GlobSpec extends CommonSpec with BeforeAndAfterAll {
     // Special target with path name components as wildcards
     specialTree = testDir / "special"
 
-    // regex
-    mkdir(specialTree)
-    regexWildcardPath = mkdir(specialTree / ".*" )
-    mkdir(specialTree / ".*" / "a" )
-    touch(specialTree / ".*" / "a" / "a.txt")
+    // Windows does not support '*' in file names
+    if (isUnixOS) {
+      // regex
+      mkdir(specialTree)
+      regexWildcardPath = mkdir(specialTree / ".*")
+      mkdir(specialTree / ".*" / "a")
+      touch(specialTree / ".*" / "a" / "a.txt")
 
-    // glob
-    globWildcardPath = mkdir(specialTree / "**" )
-    mkdir(specialTree / "**" / "a" )
-    touch(specialTree / "**" / "a" / "a.txt")
+      // glob
+      globWildcardPath = mkdir(specialTree / "**")
+      mkdir(specialTree / "**" / "a")
+      touch(specialTree / "**" / "a" / "a.txt")
+    }
 
     ()
   }
@@ -300,6 +303,7 @@ class GlobSpec extends CommonSpec with BeforeAndAfterAll {
   }
 
   it should "not use dir name as wildcard (e.g. dirname is **)" in {
+    assume(isUnixOS)
     val d = globWildcardPath // "path" / "with" / "**"
     val paths = d.glob("*.txt")
 
@@ -337,6 +341,7 @@ class GlobSpec extends CommonSpec with BeforeAndAfterAll {
   }
 
   it should "not use dir name as wildcard (e.g. dirname is .*)" in {
+    assume(isUnixOS)
     val d = regexWildcardPath // "path" / "with" / ".*"
     val paths = d.glob("a\\.txt")(File.PathMatcherSyntax.regex)
     assert(paths.isEmpty)


### PR DESCRIPTION
Windows does not support `*` character in directory or file names, so we shouldn't create them in the tests, nor perform those tests

The escaped path was getting stripped of all `\` characters.

Lots more tests still fail on windows, I'm looking into those.