### PR TITLE
Fix #115: symbolicLink returns relative path if target is relative

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -414,7 +414,7 @@ class File private(val path: Path) {
     * @return Some(target) if this is a symbolic link (to target) else None
     */
   def symbolicLink: Option[File] =
-    when(isSymbolicLink)(Files.readSymbolicLink(path))
+    when(isSymbolicLink)(new File(Files.readSymbolicLink(path)))
 
   /**
     * @return true if this file (or the file found by following symlink) is a directory

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -294,6 +294,12 @@ class FileSpec extends CommonSpec {
     val magicWord = "Hello World"
     t1 writeText magicWord
     // link
+    // to relative target
+    val b0 = b1.sibling("b0")
+    java.nio.file.Files.createSymbolicLink(b0.path, java.nio.file.Paths.get("b1"))
+    b0.symbolicLink should not be empty
+    b0.symbolicLink.get.path.isAbsolute shouldBe false
+    // to absolute target
     b1.linkTo(a1, symbolic = true)
     ln_s(b2, t2)
     (b1 / "t1.txt").contentAsString shouldEqual magicWord


### PR DESCRIPTION
Here's my attempt to fix https://github.com/pathikrit/better-files/issues/115
I couldn't find a way to create a symbolic link pointing to a relative target using better files, which is why I used `java.nio.file.Files.createSymbolicLink` directly. 
Happy to make any modification you think is appropriate.