### PR TITLE
Catch exception while registering WatchService

### DIFF
--- a/core/src/main/scala/better/files/ThreadBackedFileMonitor.scala
+++ b/core/src/main/scala/better/files/ThreadBackedFileMonitor.scala
@@ -50,6 +50,7 @@ abstract class ThreadBackedFileMonitor(val root: File, maxDepth: Int) extends Fi
     }
 
     toWatch.foreach { f =>
+      // The `Try` is not used intentionally, because it would generate many many `Try` instances (one for each file) which is not very effective
       try { f.register(service) } catch { case NonFatal(e) => onException(e) }
     }
   }

--- a/core/src/main/scala/better/files/ThreadBackedFileMonitor.scala
+++ b/core/src/main/scala/better/files/ThreadBackedFileMonitor.scala
@@ -2,6 +2,8 @@ package better.files
 
 import java.nio.file._
 
+import scala.util.control.NonFatal
+
 /**
   * A thread based implementation of the FileMonitor
   *
@@ -46,7 +48,10 @@ abstract class ThreadBackedFileMonitor(val root: File, maxDepth: Int) extends Fi
     } else {
       when(file.exists)(file.parent).iterator  // There is no way to watch a regular file; so watch its parent instead
     }
-    toWatch.foreach(_.register(service))
+
+    toWatch.foreach { f =>
+      try { f.register(service) } catch { case NonFatal(e) => onException(e) }
+    }
   }
 
   override def start() = {


### PR DESCRIPTION
When I start watching some directory, which contains a file with too low persmissions, it ends with:
```
java.io.UncheckedIOException: java.nio.file.AccessDeniedException: /mnt/fotky/lost+found
        at java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:88)
        at java.nio.file.FileTreeIterator.hasNext(FileTreeIterator.java:104)
        at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1811)
        at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:294)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
        at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:300)
        at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
        at better.files.Implicits$JStreamOps.$anonfun$toAutoClosedIterator$2(Implicits.scala:256)
        at better.files.package$$anon$3$$anon$2.hasNext(package.scala:39)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:447)
        at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:500)
        at scala.collection.Iterator.foreach(Iterator.scala:929)
        at scala.collection.Iterator.foreach$(Iterator.scala:929)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1406)
        at better.files.ThreadBackedFileMonitor.watch(ThreadBackedFileMonitor.scala:49)
        at better.files.ThreadBackedFileMonitor.start(ThreadBackedFileMonitor.scala:53)
        at cz.jenda.gdrivebackup.FileScanner.<init>(FileScanner.scala:20)
        at cz.jenda.gdrivebackup.GDriveBackup$.$anonfun$new$2(GDriveBackup.scala:131)
        at scala.util.Success.foreach(Try.scala:249)
        at scala.concurrent.Future.$anonfun$foreach$1$adapted(Future.scala:224)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: java.nio.file.AccessDeniedException: /mnt/fotky/lost+found
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:427)
        at java.nio.file.Files.newDirectoryStream(Files.java:457)
        at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:300)
        at java.nio.file.FileTreeWalker.next(FileTreeWalker.java:372)
        at java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:84)
```
This PR should catch thrown exception which caused failure of whole watching process.