### PR TITLE
Update `ln` param order in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ file.clear()      // If directory, deletes all children; if file clears contents
 file.renameTo(newName: String)
 file.moveTo(destination)
 file.copyTo(destination)       // unlike the default API, also works on directories (copies recursively)
-file.linkTo(destination)                     // ln file destination
-file.symbolicLinkTo(destination)             // ln -s file destination
+file.linkTo(destination)                     // ln destination file
+file.symbolicLinkTo(destination)             // ln -s destination file
 file.{checksum, md5, sha1, sha256, sha512, digest}   // also works for directories
 file.setOwner(user: String)      // chown user file
 file.setGroup(group: String)     // chgrp group file


### PR DESCRIPTION
The first form for `ln` in man page :
`Usage: ln [OPTION]... TARGET LINK_NAME`

`ln -s theAlreadyExistingFile theLinkThatWillBeCreatedByLnCommand`

It's like `cp` and `mv`, first the existing file, second the created file.