### PR TITLE
upgrade to sbt 0.13.16

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16


### PR DESCRIPTION
no special reason, just keeping current. also, this helps
keep compatibility with the Scala community build, which uses
the same sbt version to build everything.