### PR TITLE
#77 - overwriting bug and #44 - better unix compability for cp and mv

### DIFF
--- a/core/src/main/scala/better/files/Dsl.scala
+++ b/core/src/main/scala/better/files/Dsl.scala
@@ -61,11 +61,21 @@ object Dsl {
       !(file === that)
   }
 
-  def cp(file1: File, file2: File): File =  //todo return file2.type when SI-4751 is fixed
-    file1.copyTo(file2, overwrite = true)
+  def cp(file1: File, file2: File): File = { //todo return file2.type when SI-4751 is fixed
+    if (file2.isDirectory) {
+      file1.copyTo(file2 / file1.name, overwrite = true)
+    } else {
+      file1.copyTo(file2, overwrite = true)
+    }
+  }
 
-  def mv(file1: File, file2: File): File =
-    file1.moveTo(file2, overwrite = true)
+  def mv(file1: File, file2: File): File = {
+    if (file2.isDirectory) {
+      file1.moveTo(file2 / file1.name, overwrite = true)
+    } else {
+      file1.moveTo(file2, overwrite = true)
+    }
+  }
 
   def rm(file: File): File =
     file.delete(swallowIOExceptions = true)

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -690,7 +690,6 @@ class File private(val path: Path)(implicit val fileSystem: FileSystem = path.ge
     */
   def copyTo(destination: File, overwrite: Boolean = false)(implicit copyOptions: File.CopyOptions = File.CopyOptions(overwrite)): destination.type = {
     if (isDirectory) {//TODO: maxDepth?
-      if (overwrite) destination.delete(swallowIOExceptions = true)
       Files.walkFileTree(path, new SimpleFileVisitor[Path] {
         def newPath(subPath: Path): Path = destination.path.resolve(path.relativize(subPath))
 

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -353,7 +353,7 @@ class FileSpec extends CommonSpec {
     assume(isUnixOS)
     val magicWord = "Hello World"
     t1 writeText magicWord
-    t1.linkTo(t3)
+    t1.linkTo(t3, symbolic = false)
     (a1 / "t3.scala.txt").contentAsString shouldEqual magicWord
   }
 

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -353,7 +353,7 @@ class FileSpec extends CommonSpec {
     assume(isUnixOS)
     val magicWord = "Hello World"
     t1 writeText magicWord
-    t1.linkTo(t3, symbolic = false)
+    t1.linkTo(t3)
     (a1 / "t3.scala.txt").contentAsString shouldEqual magicWord
   }
 
@@ -391,6 +391,12 @@ class FileSpec extends CommonSpec {
     cp(fb / "t3", fb / "t5")
     (fb / "t5" / "t4.txt").contentAsString shouldEqual "Hello World"
     (fb / "t3").exists shouldBe true
+    (fb / "t5" / "t3" / "t1.txt").createIfNotExists(createParents = true).writeText("Will not be overwrited")
+    (fb / "t5" / "t3" / "t4.txt").createIfNotExists(createParents = true).writeText("Will be overwrited")
+    cp(fb / "t3", fb / "t5")
+    (fb / "t5" / "t3" / "t1.txt").contentAsString shouldEqual "Will not be overwrited"
+    (fb / "t5" / "t3" / "t4.txt").contentAsString shouldEqual "Hello World"
+    (fb / "t5" / "t4.txt").contentAsString shouldEqual "Hello World"
   }
 
   it should "move" in {


### PR DESCRIPTION
I think that `if (overwrite) destination.delete(swallowIOExceptions = true)` in `File.copyTo` is useless because files in target dir will be overwrited by `File.CopyOptions(overwrite)`.

`File.copyTo` without this line works like a UNIX `cp` util. I added spec that demonstrate this.

Also I changed logic of `cp` and `mc` dsl functions for better compability with UNIX commands.