### PR TITLE
Add regex matcher util

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -15,6 +15,7 @@ import javax.xml.bind.DatatypeConverter
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Properties
+import scala.util.matching.Regex
 
 /**
   * Scala wrapper around java.nio.files.Path
@@ -524,8 +525,22 @@ class File private(val path: Path)(implicit val fileSystem: FileSystem = path.ge
     *                    e.g. instead of **//*.txt we just use *.txt
     * @return Set of files that matched
     */
+  //TODO: Consider removing `syntax` as implicit. You often want to control this on a per method call basis
   def glob(pattern: String, includePath: Boolean = true)(implicit syntax: File.PathMatcherSyntax = File.PathMatcherSyntax.default, visitOptions: File.VisitOptions = File.VisitOptions.default): Files =
     pathMatcher(syntax, includePath)(pattern).matches(this)(visitOptions)
+
+  /**
+    * Util to match from this file's path using Regex
+    *
+    * @param includePath If true, we don't need to set path glob patterns
+    *                    e.g. instead of **//*.txt we just use *.txt
+    * @see glob
+    * @return Set of files that matched
+    */
+  //TODO: Consider removing `syntax` as implicit. You often want to control this on a per method call basis
+  def regex(pattern: Regex, includePath: Boolean = true)(implicit syntax: File.PathMatcherSyntax = File.PathMatcherSyntax.regex, visitOptions: File.VisitOptions = File.VisitOptions.default): Files = {
+    glob(pattern.regex, includePath)
+  }
 
   /**
     * More Scala friendly way of doing Files.walk

--- a/core/src/test/scala/better/files/GlobSpec.scala
+++ b/core/src/test/scala/better/files/GlobSpec.scala
@@ -329,6 +329,16 @@ class GlobSpec extends CommonSpec with BeforeAndAfterAll {
     verify(paths, refPaths, globTree)
   }
 
+  it should "match the same if `Regex` is used" in {
+    val pattern = (".*" + regexpPathSep + ".*\\.txt").r
+
+    val pathsGlob = globTree.glob(pattern.regex)(File.PathMatcherSyntax.regex)
+    val pathsRegex = globTree.regex(pattern)
+
+    verify(pathsRegex, pathsGlob.toSeq.map(_.toString), globTree)
+
+  }
+
   it should "use parent dir for matching (e.g. plain 'subdir/*.ext' instead of '**/subdir/*.ext)" in {
     // e.g. check that b nor c are matched, nor b/a
     val refPaths = Seq(


### PR DESCRIPTION
Would be nice to simply overload `glob` but we can't as there are default args