### PR TITLE
Remove insecure resolver in plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-
 addSbtPlugin("com.eed3si9n"       %   "sbt-unidoc"              % "0.3.2")
 addSbtPlugin("com.github.gseitz"  %   "sbt-release"             % "1.0.0")
 addSbtPlugin("com.jsuereth"       %   "sbt-pgp"                 % "1.0.0")


### PR DESCRIPTION
Currently, `project/plugins.sbt` adds a repository with an `http://` URL. This is a security risk. Anyone building better-files will be exposed to malicious code being inserted into artifacts downloaded from that repository, because it is not protected by TLS.

Moreover, it doesn't seem to be needed. JGit is in Central. So, I simply removed it.