### PR TITLE
Fix typo in CommonSpec#isUnixOS

### DIFF
--- a/core/src/test/scala/better/files/CommonSpec.scala
+++ b/core/src/test/scala/better/files/CommonSpec.scala
@@ -4,14 +4,12 @@ import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.Properties.{isLinux, isMac}
 
 trait CommonSpec extends FlatSpec with BeforeAndAfterEach with Matchers {
   val isCI = sys.env.get("CI").exists(_.toBoolean)
 
-  val isUnixOS = sys.props.get("os.name") match {
-    case Some("Linux" | "MaxOS") => true
-    case _ => false
-  }
+  val isUnixOS = isLinux || isMac
 
   def sleep(t: FiniteDuration = 2 second) = Thread.sleep(t.toMillis)
 }


### PR DESCRIPTION
I noticed that, in `CommonSpec`, `isUnixOS` will not actually be `true` on a Mac because of a typo.

Since the Scala standard library already comes with OS detection code, this PR changes `CommonSpec` to use that instead.