### PR TITLE
Treat symlinks transparently in createDirectories()

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -224,8 +224,12 @@ class File private(val path: Path)(implicit val fileSystem: FileSystem = path.ge
     * @param attributes
     * @return
     */
-  def createDirectories()(implicit attributes: File.Attributes = File.Attributes.default): this.type = {
-    Files.createDirectories(path, attributes: _*)
+  def createDirectories()(implicit attributes: File.Attributes = File.Attributes.default, linkOptions: File.LinkOptions = File.LinkOptions.default): this.type = {
+    try {
+      Files.createDirectories(path, attributes: _*)
+    } catch {
+      case _: FileAlreadyExistsException if Files.isDirectory(path, linkOptions: _*) =>
+    }
     this
   }
 

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -1,9 +1,9 @@
 package better.files
 
-import java.nio.file.FileSystems
+import java.nio.file.{FileAlreadyExistsException, FileSystems, Files => JFiles}
 
 import better.files.Dsl._
-import better.files.File.{home, root}
+import better.files.File.{LinkOptions, home, root}
 
 import scala.language.postfixOps
 import scala.util.Try
@@ -301,6 +301,19 @@ class FileSpec extends CommonSpec {
       assert(file.parent.exists)
       file.writeText("Hello world")
       assert(file.contentAsString === "Hello world")
+    }
+  }
+
+  it should "treat symlinks transparently in convenience methods" in {
+    File.usingTemporaryDirectory() {dir =>
+      val realDir = dir / "a"
+      val dirSymlink = dir / "b"
+      realDir.createDirectory()
+      JFiles.createSymbolicLink(dirSymlink.path, realDir.path)
+      dirSymlink.createDirectories()
+      assertThrows[FileAlreadyExistsException] {
+        dirSymlink.createDirectories()(linkOptions = LinkOptions.noFollow)
+      }
     }
   }
 


### PR DESCRIPTION
JDK Files.createDirectories() fails if the target is a symlink to a
directory (see #171 and [JDK-8130464](https://bugs.openjdk.java.net/browse/JDK-8130464)). Our createDirectories() method gained
LinkOptions implicit parameter which specifies whether we should behave
like JDK. We don't by default.