### PR TITLE
Bump sbt version to 0.13.16.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,20 @@ machine:
   java:
     version: oraclejdk8
 
+dependencies:
+  pre:
+    - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.16.deb
+    - sudo dpkg -i sbt-0.13.16.deb
+# see https://circleci.com/docs/1.0/language-scala/#using-a-custom-version-of-sbt
+# Remove above three lines when CircleCI supports newer SBT versions
+  post:
+    - find ~/.ivy2/cache -name "ivydata-*.properties" -print -delete
+    - find ~/.sbt        -name "*.lock"               -print -delete
+  cache_directories:
+    - "~/.ivy2/cache"
+    - "~/.sbt"
+    - "~/.m2"
+
 test:
   override:
     - sbt clean coverage +test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-# This can only be upto version supported by CircleCI. See: https://circleci.com/docs/1.0/language-scala/
-sbt.version=0.13.9
+sbt.version=0.13.16


### PR DESCRIPTION
Although CircleCI only supports `0.13.9`, we can still update sbt version manually.