### PR TITLE
Fix missing source code at other jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ jobs:
             - ~/.sbt
           key: sbt-dependencies--{{ checksum "project/build.properties" }}
       - run: sbt coverage +test
-  coverage:
-    docker:
-      - image: aa8y/sbt:ci
-    steps:
       - run: sbt updateImpactSubmit coverageReport coverageAggregate codacyCoverage
       - run: bash <(curl -s https://codecov.io/bash)
   deploy:
@@ -33,6 +29,11 @@ jobs:
     environment:
       SBT_GHPAGES_COMMIT_MESSAGE: 'Publishing Scaladoc [ci skip]'
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - build-dependencies-{{ checksum "build.sbt" }}
+          - sbt-dependencies--{{ checksum "project/build.properties" }}
       - run: git config --global user.email "pathikritbhowmick@msn.com"
       - run: git config --global user.name "circle-ci"
       - run: git config --global push.default simple
@@ -42,12 +43,9 @@ workflows:
   build-coverage-deploy:
     jobs:
       - build
-      - coverage:
+      - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
-      - deploy:
-          requires:
-            - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,10 @@ jobs:
           paths:
             - ~/.sbt
           key: sbt-dependencies--{{ checksum "project/build.properties" }}
-      - run: sbt coverage +test
-      - run: sbt updateImpactSubmit coverageReport coverageAggregate codacyCoverage
-      - run: bash <(curl -s https://codecov.io/bash)
   deploy:
     docker:
       - image: aa8y/sbt:ci
+    working_directory: /usr/src/app
     environment:
       SBT_GHPAGES_COMMIT_MESSAGE: 'Publishing Scaladoc [ci skip]'
     steps:
@@ -34,6 +32,8 @@ jobs:
           keys:
           - build-dependencies-{{ checksum "build.sbt" }}
           - sbt-dependencies--{{ checksum "project/build.properties" }}
+      - run: sbt coverage +test updateImpactSubmit coverageReport coverageAggregate codacyCoverage
+      - run: bash <(curl -s https://codecov.io/bash)
       - run: git config --global user.email "pathikritbhowmick@msn.com"
       - run: git config --global user.name "circle-ci"
       - run: git config --global push.default simple


### PR DESCRIPTION
Fix [build failed](https://circleci.com/gh/pathikrit/better-files/1038).

In 2.0, workflows start jobs at different containers. We have to checkout source code at different jobs. In the meantime, I merged `build` and `coverage`, since `sbt coverageRepor` needs to run after `sbt coverage +test`.