### PR TITLE
Module-safe File.resource & resourceAsStream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,9 @@ lazy val core = (project in file("core"))
   .settings(publishSettings: _*)
   .settings(
     name := repo,
-    description := "Simple, safe and intuitive I/O in Scala"
+    description := "Simple, safe and intuitive I/O in Scala",
+    (scalacOptions in doc) ++= Seq("-skip-packages better.files._class_resources"),
+    libraryDependencies += Dependencies.scalaReflect(scalaVersion.value) % Provided
   )
 
 lazy val akka = (project in file("akka"))

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -1268,7 +1268,7 @@ object File {
     * @return
     */
   def resource(name: String): File =
-    File(currentClassLoader().getResource(name))
+    macro _class_resources.Macros.file
 
   /**
     * Copies a resource into a file
@@ -1277,9 +1277,13 @@ object File {
     * @param destination File where resource is copied into, if not specified a temp file is created
     * @return
     */
+  @deprecated(
+    "Use `File.resource(name) copyTo destination` instead. This method is likely to fail if the resource is in a Java module, even if this method is called from inside that same module.\n\nNote that, unlike this method, copyTo does not overwrite by default. Use `File.resource(name) copyTo (destination, overwrite=true)` if you want to overwrite the destination file.",
+    "3.4.1"
+  )
   def copyResource(name: String)(destination: File = File.newTemporaryFile(prefix = name)): destination.type = {
     for {
-      in  <- resourceAsStream(name).autoClosed
+      in  <- Thread.currentThread.getContextClassLoader.getResourceAsStream(name).autoClosed
       out <- destination.outputStream
     } in.pipeTo(out)
     destination

--- a/core/src/main/scala/better/files/_class_resources/Macros.scala
+++ b/core/src/main/scala/better/files/_class_resources/Macros.scala
@@ -1,0 +1,20 @@
+package better.files
+package _class_resources
+
+import scala.reflect.macros.blackbox
+
+private[files] final class Macros(val c: blackbox.Context) {
+  import c.universe._
+
+  private[this] def ccl =
+    q"_root_.java.lang.Thread.currentThread.getContextClassLoader"
+
+  def file(name: Tree): Tree =
+    q"_root_.better.files.File($ccl.getResource($name))"
+
+  def stream(name: Tree): Tree =
+    streamBuf(name, q"_root_.better.files.DefaultBufferSize")
+
+  def streamBuf(name: Tree, bufferSize: Tree): Tree =
+    q"new _root_.java.io.BufferedInputStream($ccl.getResourceAsStream($name), $bufferSize)"
+}

--- a/core/src/main/scala/better/files/package.scala
+++ b/core/src/main/scala/better/files/package.scala
@@ -26,13 +26,16 @@ package object files extends Implicits {
 
   type Files = Iterator[File]
 
+  def resourceAsStream(name: String): InputStream =
+    macro _class_resources.Macros.stream
+
   /**
     * If bufferSize is set to less than or equal to 0, we don't buffer
     * @param bufferSize
     * @return
     */
-  def resourceAsStream(name: String, bufferSize: Int = DefaultBufferSize): InputStream =
-    currentClassLoader().getResourceAsStream(name).buffered(bufferSize)
+  def resourceAsStream(name: String, bufferSize: Int): InputStream =
+    macro _class_resources.Macros.streamBuf
 
   // Some utils:
   private[files] def newMultiMap[A, B]: mutable.MultiMap[A, B] =

--- a/core/src/test/resources/better/files/test-file.txt
+++ b/core/src/test/resources/better/files/test-file.txt
@@ -1,0 +1,3 @@
+This is the test-file.txt file.
+
+It is used to verify that loading of class loader resources works correctly.

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -592,5 +592,14 @@ class FileSpec extends CommonSpec {
     }
 
     checkStream(resourceAsStream("better/files/test-file.txt"))
+
+    {
+      // Also verify that copyTo works properly with File.resource. This is needed because the deprecation message for File.copyResource says to use that instead.
+      val tmpFile = File.newTemporaryFile("test-file.txt")
+      try {
+        File.resource("better/files/test-file.txt") copyTo (tmpFile, overwrite = true)
+        check(tmpFile)
+      } finally tmpFile.delete()
+    }
   }
 }

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -1,5 +1,7 @@
 package better.files
 
+import java.io.InputStream
+import java.nio.charset.StandardCharsets.US_ASCII
 import java.nio.file.{FileAlreadyExistsException, FileSystems, Files => JFiles}
 
 import better.files.Dsl._
@@ -567,5 +569,28 @@ class FileSpec extends CommonSpec {
       .asInstanceOf[com.sun.management.UnixOperatingSystemMXBean]
       .getOpenFileDescriptorCount
     assert((File.numberOfOpenFileDescriptors() - expected).abs <= 10)
+  }
+
+  it should "load class loader resources correctly" in {
+    val expectedText = "This is the test-file.txt file."
+
+    def check(f: File) = {
+      val text = f.contentAsString(US_ASCII).substring(0, expectedText.length)
+      assert(text === expectedText)
+    }
+
+    check(File.resource("better/files/test-file.txt"))
+
+    def checkStream(in: InputStream) = {
+      try {
+        val chars = new Array[Char](expectedText.length)
+        in.reader(US_ASCII).read(chars)
+        val text = new String(chars)
+
+        assert(text === expectedText)
+      } finally in.close()
+    }
+
+    checkStream(resourceAsStream("better/files/test-file.txt"))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,4 +12,6 @@ object Dependencies {
   // Used in Benchmarks only
   val commonsio  = "commons-io" % "commons-io" % "2.6"
   val fastjavaio = "fastjavaio" % "fastjavaio" % "1.0" from "https://github.com/williamfiset/FastJavaIO/releases/download/v1.0/fastjavaio.jar"
+
+  def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version
 }


### PR DESCRIPTION
Implements `File.resource` and `resourceAsStream` with macros, to avoid failure in some situations.

`ClassLoader#getResource[AsStream]` is caller-sensitive: access to the resource is determined in part by where the methods are called from. This is especially important in the presence of Java ≥ 9 modules, because access is denied by default to resources (except class files and META-INF) in other modules. Therefore, calling these methods through a library like better-files from inside a Java 9+ module will usually fail.

Implementing these methods as macros should solve the problem, by inlining the `getResource[AsStream]` calls in the modules they're really supposed to be called from.

This PR also adds tests for `File.resource` and `resourceAsStream`.

Note: This PR deprecates `File.copyResource`, and leaves its behavior unchanged. That method is impossible to implement as a macro, because of the default parameter value in its second parameter list. (Macros are not allowed to have default parameter values.) The deprecation message explains what to do instead.

Note: Dotty's new inline behavior would make this change unnecessary. Unfortunately, while Scala 2 has an `@inline` annotation, the compiler is not required to honor it, and doesn't by default. The only way to force inlining in Scala 2 is with a macro.