### PR TITLE
More ways to look up class resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val commonSettings = Seq(
   crossVersion := CrossVersion.binary,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint"),
   scalacOptions --= ignoreScalacOptions(scalaVersion.value),
+  scalacOptions in (Compile,doc) += "-groups",
   libraryDependencies += Dependencies.scalatest,
   updateImpactOpenBrowser := false,
   compile in Compile := (compile in Compile).dependsOn(formatAll).value,

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val commonSettings = Seq(
   crossVersion := CrossVersion.binary,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint"),
   scalacOptions --= ignoreScalacOptions(scalaVersion.value),
-  scalacOptions in (Compile,doc) += "-groups",
+  scalacOptions in (Compile, doc) += "-groups",
   libraryDependencies += Dependencies.scalatest,
   updateImpactOpenBrowser := false,
   compile in Compile := (compile in Compile).dependsOn(formatAll).value,
@@ -42,7 +42,7 @@ lazy val core = (project in file("core"))
     name := repo,
     description := "Simple, safe and intuitive I/O in Scala",
     libraryDependencies += Dependencies.scalaReflect(scalaVersion.value) % "provided,optional",
-    libraryDependencies ++= Dependencies.silencer,
+    libraryDependencies ++= Dependencies.silencer
   )
 
 lazy val akka = (project in file("akka"))

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ lazy val core = (project in file("core"))
   .settings(
     name := repo,
     description := "Simple, safe and intuitive I/O in Scala",
-    libraryDependencies += Dependencies.scalaReflect(scalaVersion.value) % Provided
+    libraryDependencies += Dependencies.scalaReflect(scalaVersion.value) % "provided,optional",
+    libraryDependencies ++= Dependencies.silencer,
   )
 
 lazy val akka = (project in file("akka"))

--- a/core/src/main/scala/better/files/Resource.scala
+++ b/core/src/main/scala/better/files/Resource.scala
@@ -3,7 +3,10 @@ package better.files
 import java.io.InputStream
 import java.net.URL
 
-import scala.reflect.macros.blackbox
+import com.github.ghik.silencer.silent
+
+import scala.annotation.compileTimeOnly
+import scala.reflect.macros.{ReificationException, blackbox}
 
 /**
   * Class to encapsulate resource related APIs
@@ -26,6 +29,99 @@ object Resource {
   def asFile(name: String): File =
     macro Macros.asFileImpl
 
+  /*
+   * Ordinarily, we'd have a trait ResourceLookup with apply/url/asFile methods, make object Resource be the default implementation (using the context class loader), and make “modifiers” like `at` and `my` return different ResourceLookup implementations (with suitable lookup behavior).
+   *
+   * But we're using macros here. Macros cannot have run-time polymorphism like that, because they run at compile time! Instead, we make the modifier methods stubs (they just return this), and the macros look whether they were called on the object returned by a modifier method (even though it's just this).
+   *
+   * It's a hack, but it works, and the resulting API is as easy to use as the idiomatic trait-and-instances approach.
+   */
+
+  /**
+    * Look up class resource files.
+    *
+    * When this method is part of a call to the lookup methods `apply`, `url`, and `asFile`, it changes how they look up resource files. The `name` parameter to those methods is instead interpreted as a path relative to the JVM class file for `T`. In other words, they look up resources using [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResource(java.lang.String) Class#getResource]] and [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResourceAsStream(java.lang.String) Class#getResourceAsStream]].
+    *
+    * For example, if `com.example.ExampleClass` is given for `T`, then the resource file will be searched for in the `com/example` folder containing `ExampleClass.class`.
+    *
+    * If you want to look up resource files relative to the call site instead (that is, you want a class to look up one of its own resources), use the `my` method instead.
+    *
+    * @example {{{ Resource.at[YourClass].asFile("config.properties") }}}
+    * @note This method, if used, must be a direct part of a call to the aforementioned lookup methods. If used in any other way, there will be a compile error. For example, this will not work:
+    *       {{{
+    *       val at = Resource.at[SomeClass]
+    *       at.asFile("some-file.txt")
+    *       }}}
+    *
+    *       The reason for this is that this method exists only to be seen by the macros implementing the lookup methods. The macros look whether this method was called, and change their behavior accordingly. If called by run-time reflection, this method does nothing.
+    * @tparam T The class to look up from.
+    * @return This object. Call apply, url, or asFile on the returned object.
+    */
+  // These are stub methods, so ignore warnings about their parameters being unused.
+  @compileTimeOnly("you must directly call apply, url, or asFile on the returned object")
+  def at[@silent T]: this.type = this
+
+  /**
+    * Look up class resource files.
+    *
+    * When this method is part of a call to the lookup methods `apply`, `url`, and `asFile`, it changes how they look up resource files. The `name` parameter to those methods is instead interpreted as a path relative to the given `lookupClass`. In other words, they look up resources using [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResource(java.lang.String) Class#getResource]] and [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResourceAsStream(java.lang.String) Class#getResourceAsStream]].
+    *
+    * For example, if `classOf[com.example.ExampleClass]` is given, then the resource file will be searched for in the `com/example` folder containing `ExampleClass.class`.
+    *
+    * If you want to look up resource files relative to the call site instead (that is, you want a class to look up one of its own resources), use the `my` method instead.
+    *
+    * @example {{{ Resource.at(Class.forName("your.AppClass")).asFile("config.properties") }}}
+    * @note This method, if used, must be a direct part of a call to the aforementioned lookup methods. If used in any other way, there will be a compile error. For example, this will not work:
+    *       {{{
+    *       val at = Resource.at(someClass)
+    *       at.asFile("some-file.txt")
+    *       }}}
+    *
+    *       The reason for this is that this method exists only to be seen by the macros implementing the lookup methods. The macros look whether this method was called, and change their behavior accordingly. If called by run-time reflection, this method does nothing.
+    * @param lookupClass The class to look up from.
+    * @return This object. Call apply, url, or asFile on the returned object.
+    */
+  @compileTimeOnly("you must directly call apply, url, or asFile on the returned object")
+  def at(@silent lookupClass: Class[_]): this.type = this
+
+  /**
+    * Look up own resource files.
+    *
+    * When this method is part of a call to the lookup methods `apply`, `url`, and `asFile`, it changes how they look up resource files. The `name` parameter to those methods is instead interpreted as a path relative to the JVM class file for the call site. In other words, they look up resources using [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResource(java.lang.String) Class#getResource]] and [[https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getResourceAsStream(java.lang.String) Class#getResourceAsStream]].
+    *
+    * For example, if the call to this method appears inside the class `com.example.ExampleClass`, then the resource file will be searched for in the `com/example` folder containing `ExampleClass.class`.
+    *
+    * @example {{{ Resource.my.asFile("config.properties") }}}
+    * @note This method, if used, must be a direct part of a call to the aforementioned lookup methods. If used in any other way, there will be a compile error. For example, this will not work:
+    *       {{{
+    *       val my = Resource.my
+    *       my.asFile("some-file.txt")
+    *       }}}
+    *
+    *       The reason for this is that this method exists only to be seen by the macros implementing the lookup methods. The macros look whether this method was called, and change their behavior accordingly. If called by run-time reflection, this method does nothing.
+    * @return This object. Call apply, url, or asFile on the returned object.
+    */
+  @compileTimeOnly("you must directly call apply, url, or asFile on the returned object")
+  def my: this.type = this
+
+  /**
+    * Look up resource files using the specified ClassLoader.
+    *
+    * When this method is part of a call to the lookup methods `apply`, `url`, and `asFile`, it changes which ClassLoader they use to look up resource files. By default, it's the current thread's context class loader, but using this method designates another ClassLoader to use instead.
+    *
+    * @example {{{ Resource.from(appClassLoader).asFile("your/config.properties") }}}
+    * @note This method, if used, must be a direct part of a call to the aforementioned lookup methods. If used in any other way, there will be a compile error. For example, this will not work:
+    *       {{{
+    *       val from = Resource.from(appClassLoader)
+    *       from.asFile("some-file.txt")
+    *       }}}
+    *
+    *       The reason for this is that this method exists only to be seen by the macros implementing the lookup methods. The macros look whether this method was called, and change their behavior accordingly. If called by run-time reflection, this method does nothing.
+    * @return This object. Call apply, url, or asFile on the returned object.
+    */
+  @compileTimeOnly("you must directly call apply, url, or asFile on the returned object")
+  def from(@silent cl: ClassLoader): this.type = this
+
   /**
     * Why do we need macros?
     * See: https://github.com/pathikrit/better-files/pull/227
@@ -33,16 +129,45 @@ object Resource {
   private[this] class Macros(val c: blackbox.Context) {
     import c.universe._
 
-    private[this] def threadContextClassLoader =
-      q"_root_.java.lang.Thread.currentThread.getContextClassLoader"
+    private[this] def lookupSource: Tree = {
+      object CallToResource {
+        def unapply(tree: Tree): Option[Tree] = {
+          if (tree.symbol.owner == symbolOf[Resource.type]) Some(tree)
+          else None
+        }
+      }
+
+      (c.prefix.tree match {
+        case CallToResource(q"$_.at[$t]") =>
+          try c.reifyRuntimeClass(t.tpe, concrete = true)
+          catch {
+            case e: ReificationException =>
+              c.abort(t.pos, s"$t is not a concrete type")
+          }
+
+        case CallToResource(q"$_.at($lookupClass)") => lookupClass
+        case CallToResource(q"$_.from($cl)")        => cl
+
+        case CallToResource(q"$_.my") =>
+          c.reifyEnclosingRuntimeClass match {
+            case EmptyTree =>
+              // The documentation for reifyEnclosingRuntimeClass claims that this is possible, somehow. I have no idea where a macro call could possibly appear that's not inside a scope that compiles to a class file, but I guess we'll have to deal with it.
+              c.abort(c.enclosingPosition,
+                      "cannot use ‘my’ here, because this location doesn't correspond to a Java class file")
+            case t => t
+          }
+
+        case _ => q"_root_.java.lang.Thread.currentThread.getContextClassLoader"
+      }): @silent // scalac generates bogus unused pattern variable warnings here.
+    }
 
     def asFileImpl(name: c.Expr[String]): Tree =
-      q"_root_.better.files.File($threadContextClassLoader.getResource($name))"
+      q"_root_.better.files.File($lookupSource.getResource($name))"
 
     def applyImpl(name: c.Expr[String]): Tree =
-      q"$threadContextClassLoader.getResourceAsStream($name)"
+      q"$lookupSource.getResourceAsStream($name)"
 
     def urlImpl(name: c.Expr[String]): Tree =
-      q"$threadContextClassLoader.getResource($name)"
+      q"$lookupSource.getResource($name)"
   }
 }

--- a/core/src/test/resources/better/files/test_pkg/another-test-file.txt
+++ b/core/src/test/resources/better/files/test_pkg/another-test-file.txt
@@ -1,0 +1,3 @@
+This is the another-test-file.txt file.
+
+It is used to verify that loading of class loader resources works correctly.

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -568,13 +568,4 @@ class FileSpec extends CommonSpec {
       .getOpenFileDescriptorCount
     assert((File.numberOfOpenFileDescriptors() - expected).abs <= 10)
   }
-
-  it should "load class loader resources correctly" in {
-    implicit val charset = java.nio.charset.StandardCharsets.US_ASCII
-    val expectedText     = "This is the test-file.txt file."
-    val testResource     = "better/files/test-file.txt"
-
-    assert(Resource.asFile(testResource).contentAsString startsWith expectedText)
-    assert(Resource(testResource).asString() startsWith expectedText)
-  }
 }

--- a/core/src/test/scala/better/files/ResourceSpec.scala
+++ b/core/src/test/scala/better/files/ResourceSpec.scala
@@ -1,0 +1,65 @@
+package better.files
+
+import java.net.{URL, URLClassLoader}
+
+import better.files.test_pkg.ResourceSpecHelper
+
+final class ResourceSpec extends CommonSpec {
+  implicit val charset = java.nio.charset.StandardCharsets.US_ASCII
+  val testFileText     = "This is the test-file.txt file."
+  val altTestFileText  = "This is the another-test-file.txt file."
+  val testFile         = "better/files/test-file.txt"
+  val testFileRel      = "test-file.txt"
+  val testFileAltRel   = "another-test-file.txt"
+  val testFileFromCL   = "files/test-file.txt"
+
+  "Resource" can "look up from the context class loader" in {
+    assert(Resource.asFile(testFile).contentAsString startsWith testFileText)
+    assert(Resource(testFile).asString() startsWith testFileText)
+    assert(File(Resource.url(testFile)).contentAsString startsWith testFileText)
+  }
+
+  it can "look up from a specified class loader" in {
+    val clURL = new URL(Resource.my.url("ResourceSpec.class"), "../")
+    assert(clURL.toExternalForm endsWith "/")
+    val cl = new URLClassLoader(Array(clURL))
+
+    assert(Resource.from(cl).asFile(testFileFromCL).contentAsString startsWith testFileText)
+    assert(Resource.from(cl)(testFileFromCL).asString() startsWith testFileText)
+    assert(File(Resource.from(cl).url(testFileFromCL)).contentAsString startsWith testFileText)
+  }
+
+  it can "look up from the call site" in {
+    assert(Resource.my.asFile(testFileRel).contentAsString startsWith testFileText)
+    assert(Resource.my(testFileRel).asString() startsWith testFileText)
+    assert(File(Resource.my.url(testFileRel)).contentAsString startsWith testFileText)
+  }
+
+  it can "look up from a statically-known type" in {
+    assert(Resource.at[FileSpec].asFile(testFileRel).contentAsString startsWith testFileText)
+    assert(Resource.at[FileSpec](testFileRel).asString() startsWith testFileText)
+    assert(File(Resource.at[FileSpec].url(testFileRel)).contentAsString startsWith testFileText)
+  }
+
+  it can "look up from a java.lang.Class" in {
+    def testClass: Class[_] = Class forName "better.files.File"
+
+    assert(Resource.at(testClass).asFile(testFileRel).contentAsString startsWith testFileText)
+    assert(Resource.at(testClass)(testFileRel).asString() startsWith testFileText)
+    assert(File(Resource.at(testClass).url(testFileRel)).contentAsString startsWith testFileText)
+  }
+
+  it can "look up a file in another package" in {
+    assert(Resource.at[ResourceSpecHelper].asFile(testFileAltRel).contentAsString startsWith altTestFileText)
+    assert(Resource.at[ResourceSpecHelper](testFileAltRel).asString() startsWith altTestFileText)
+    assert(File(Resource.at[ResourceSpecHelper].url(testFileAltRel)).contentAsString startsWith altTestFileText)
+  }
+
+  "Resource.at" should "require a concrete type" in {
+    """def foo[T] = better.files.Resource.at[T]("foo")""" shouldNot typeCheck
+  }
+
+  "Resource.my" should "look up from the call site" in {
+    assert((new ResourceSpecHelper).myTestFile.contentAsString startsWith altTestFileText)
+  }
+}

--- a/core/src/test/scala/better/files/ResourceSpec.scala
+++ b/core/src/test/scala/better/files/ResourceSpec.scala
@@ -33,6 +33,9 @@ final class ResourceSpec extends CommonSpec {
     assert(Resource.my.asFile(testFileRel).contentAsString startsWith testFileText)
     assert(Resource.my(testFileRel).asString() startsWith testFileText)
     assert(File(Resource.my.url(testFileRel)).contentAsString startsWith testFileText)
+
+    // This tests that Resource.my uses the correct call site when called from outside the better.files package.
+    assert((new ResourceSpecHelper).myTestFile.contentAsString startsWith altTestFileText)
   }
 
   it can "look up from a statically-known type" in {
@@ -57,9 +60,5 @@ final class ResourceSpec extends CommonSpec {
 
   "Resource.at" should "require a concrete type" in {
     """def foo[T] = better.files.Resource.at[T]("foo")""" shouldNot typeCheck
-  }
-
-  "Resource.my" should "look up from the call site" in {
-    assert((new ResourceSpecHelper).myTestFile.contentAsString startsWith altTestFileText)
   }
 }

--- a/core/src/test/scala/better/files/test_pkg/ResourceSpecHelper.scala
+++ b/core/src/test/scala/better/files/test_pkg/ResourceSpecHelper.scala
@@ -1,0 +1,6 @@
+package better.files
+package test_pkg
+
+class ResourceSpecHelper {
+  def myTestFile = Resource.my.asFile("another-test-file.txt")
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,4 +14,12 @@ object Dependencies {
   val fastjavaio = "fastjavaio" % "fastjavaio" % "1.0" from "https://github.com/williamfiset/FastJavaIO/releases/download/v1.0/fastjavaio.jar"
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version
+
+  val silencer = {
+    val silencerVersion = "0.6"
+    Seq(
+      compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
+      "com.github.ghik" %% "silencer-lib" % silencerVersion % "provided,optional"
+    )
+  }
 }


### PR DESCRIPTION
This PR teaches `Resource` how to look up resources from other places: different class loaders, specific classes, or the calling class.

Specifically, it adds four new methods to `Resource`:

* `from` — look up resources using a different `ClassLoader`
* `at` — look up resources relative to a specified class (two variants)
* `my` — look up resources relative to the caller class

This uses a bit of a hack to make such “modifier” methods work with macros, but it works, and the resulting API is easy to use. See `Resource.scala` line 33 for an explanation.

This commit adds an intransitive dependency on ghik/silencer, a compiler plugin+annotation to selectively suppress warnings (like Java `@SuppressWarnings`). This is needed because:

* scalac generates bogus warnings of unused pattern variables, when the pattern contains a quasiquote.
* `Resource.{from,at,my}` are stubs; their parameters are used externally, but not by the method itself.

The dependency on ghik/silencer is in the `"provided,optional"` configuration. It appears in the generated POM, but other projects depending on better.files won't inherit that dependency. It would be more correct to use the `"compile-internal,test-internal"` configuration (see [example in sbt manual](https://www.scala-sbt.org/1.0/docs/Macro-Projects.html)), but IntelliJ doesn't understand such dependencies. This is the next best.

This also puts the existing dependency on `scala.reflect` into the `"provided,optional"` configuration.