### PR TITLE
correct readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ file.newInputStream.asObjectInputStreamUsingClassLoader(classLoader = myClassLoa
 
 The above can be simply written as:
 ```scala
-val person2: Person = file.writeSerialized(person).readDeserialized[Person]
+val person2: Person = file.writeSerialized(person).readDeserialized[Person]()
 assert(person == person2)
 ```
 


### PR DESCRIPTION
fixes `Unapplied methods are only converted to functions when a function type is expected`
broken since: f501285f7075f472b17746bbcefc844f3ded8828