### PR TITLE
Fixes #391: NPE on FileMonitor#process

### DIFF
--- a/core/src/main/scala/better/files/FileMonitor.scala
+++ b/core/src/main/scala/better/files/FileMonitor.scala
@@ -29,7 +29,7 @@ abstract class FileMonitor(val root: File, maxDepth: Int) extends File.Monitor {
 
     import scala.collection.JavaConverters._
     key.pollEvents().asScala foreach {
-      case event: WatchEvent[Path] @unchecked =>
+      case event: WatchEvent[Path] @unchecked if(event.context() != null) =>
         val target: File = path.resolve(event.context())
         if (reactTo(target)) {
           if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {


### PR DESCRIPTION
Correct NPE described in issue #391 that happens when watched directory contains 10k files. 