### PR TITLE
Enforce -release 8, close #417

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,12 +42,12 @@ lazy val commonSettings = Seq(
 
 /** We use https://github.com/DavidGregory084/sbt-tpolecat but some of these are broken */
 def myScalacOptions(scalaVersion: String, suggestedOptions: Seq[String]): Seq[String] =
-  CrossVersion.partialVersion(scalaVersion) match {
+  (CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 10)) => suggestedOptions diff Seq("-Ywarn-numeric-widen") // buggy in 2.10
     case Some((2, 11)) => suggestedOptions diff Seq("-Ywarn-value-discard") // This is broken in 2.11 for Unit types
     case Some((2, 13)) => Nil                                               // Ignore warnings for 2.13 for now
     case _             => Nil
-  }
+  }) ++ (if (scala.util.Properties.javaVersion.startsWith("1.8")) Nil else Seq("-release", "8"))
 
 lazy val core = (project in file("core"))
   .settings(commonSettings: _*)


### PR DESCRIPTION
Motivation:

Release 3.9.0 is not compatible with Java 8 because it was compile with Java 9+ without enforcing `-release` option.
As a result, bytecode is linked to the new ByteBuffer methods introduced in Java 9 that overload the ones defined in Buffer.
This causes better-files 3.9.0 to crash with NoSuchMethodErrors when running with Java 8.

Modification:

Enforce -release 8 when sbt runs with Java 9+.

Result:

sbt build now generates bytecode compatible with Java 8, whatever the runtime version (as long as code is compatible).