### PR TITLE
Add File.toResourcePathAsString helper to allow for Resource.getAsStr…

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -25,6 +25,13 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
   def pathAsString: String =
     path.toString
 
+  /**
+    * getResource[...](path) always uses "/" for separator
+    *   https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getResource(java.lang.String)
+    */
+  def toResourcePathAsString: String =
+    pathAsString.replace(JFile.separatorChar, '/')
+
   def toJava: JFile =
     new JFile(path.toAbsolutePath.toString)
 


### PR DESCRIPTION
…eam(file.toResourcePathAsString) always works on windows