### PR TITLE
exclude destination zip file from final output

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -1316,6 +1316,7 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
       output <- newZipOutputStream(File.OpenOptions.default, charset).withCompressionLevel(compressionLevel).autoClosed
       input  <- files
       file   <- input.walk()
+      if (!this.name.contentEquals(file.name))
       name = input.parent.relativize(file)
     } output.add(file, name.toString)
     this

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -523,6 +523,16 @@ class FileSpec extends CommonSpec {
     }
   }
 
+  it should "exclude destination zip when it's under directory to be zipped" in {
+    File.usingTemporaryDirectory() { dir =>
+      (dir / 'f1).touch().appendLines("Line 1", "Line 2")
+      (dir / 'f2).touch().appendLines("Line 3", "Line 4")
+      val zipFile = (dir / "f.zip")
+      val zipped = dir.zipTo(zipFile.path)
+      zipped.unzipTo().listRecursively.toList.map(_.name).forall(!_.contains("zip")) shouldBe true
+    }
+  }
+
   it should "handle backslashes in zip entry name" in {
     val list = File("core/src/test/resources/better/files/issues-262.zip")
       .unzipTo()


### PR DESCRIPTION
attempts to fix https://github.com/pathikrit/better-files/issues/268 by excluding destination zip from final zip if a directory is to be zipped to a destination under it.

So, if we want to zip a directory `hello` to a destination `hello/hello.zip`, the resulting zip file when unzipped should not contain `hello.zip` but the contents of `hello` only