### PR TITLE
use a universal converter: 

### DIFF
--- a/core/src/main/scala/better/files/Implicits.scala
+++ b/core/src/main/scala/better/files/Implicits.scala
@@ -152,6 +152,13 @@ trait Implicits extends Dispose.FlatMap.Implicits with Scanner.Read.Implicits wi
       new ZipInputStream(in, charset)
 
     /**
+      * input stream conversion using default arguments
+      * */
+    def as[T](implicit converter: InputStreamConverter[T]): T = {
+      converter.convert(in)
+    }
+
+    /**
       * If bufferSize is set to less than or equal to 0, we don't buffer
       * @param bufferSize
       * @return
@@ -195,6 +202,20 @@ trait Implicits extends Dispose.FlatMap.Implicits with Scanner.Read.Implicits wi
         out <- new ByteArrayOutputStream().autoClosed
       } yield pipeTo(out).toByteArray
     }.get()
+  }
+
+  trait InputStreamConverter[A] {
+    def convert(in: InputStream): A
+  }
+
+  object InputStreamConverter {
+    implicit val gzipInputStreamConverter = new InputStreamConverter[GZIPInputStream] {
+      override def convert(in: InputStream): GZIPInputStream = new GZIPInputStream(in, DefaultBufferSize)
+    }
+
+    implicit val zipInputStreamConverter = new InputStreamConverter[ZipInputStream] {
+      override def convert(in: InputStream): ZipInputStream = new ZipInputStream(in, DefaultCharset)
+    }
   }
 
   implicit class DigestInputStreamExtensions(in: DigestInputStream) {

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -1,6 +1,7 @@
 package better.files
 
 import java.nio.file.{FileAlreadyExistsException, FileSystems, Files => JFiles}
+import java.util.zip.GZIPInputStream
 
 import better.files.Dsl._
 import better.files.File.{home, root}
@@ -548,7 +549,7 @@ class FileSpec extends CommonSpec {
       line <- data
     } pw.println(line)
 
-    (testRoot / "test.gz").inputStream.flatMap(_.asGzipInputStream().lines).toSeq shouldEqual data
+    (testRoot / "test.gz").inputStream.flatMap(_.as[GZIPInputStream].lines).toSeq shouldEqual data
   }
 
   it should "gzip" in {


### PR DESCRIPTION
use a universal converter: https://github.com/pathikrit/better-files/issues/204.
API users who want to use non-default arguments will have to resort to `asGzipInputStream` or `asZipInputStream`