### PR TITLE
Fix/zip slip valunerability

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -152,8 +152,14 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
   )(implicit
       attributes: File.Attributes = File.Attributes.default,
       linkOptions: File.LinkOptions = File.LinkOptions.default
-  ): File =
-    (this / child).createIfNotExists(asDirectory, createParents)(attributes, linkOptions)
+  ): File = {
+    val destination = this / child
+    destination.canonicalPath match {
+      case validPath if validPath.startsWith(this.canonicalPath + JFile.separator) =>
+        destination.createIfNotExists(asDirectory, createParents)(attributes, linkOptions)
+      case _ => throw new IOException("File is outside directory.")
+    }
+  }
 
   /**
     * Create this file. If it exists, don't do anything

--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -56,7 +56,7 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
     path.getRoot
 
   def canonicalPath: String =
-    toJava.getAbsolutePath
+    toJava.getCanonicalPath
 
   def canonicalFile: File =
     toJava.getCanonicalFile.toScala
@@ -154,11 +154,8 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
       linkOptions: File.LinkOptions = File.LinkOptions.default
   ): File = {
     val destination = this / child
-    destination.canonicalPath match {
-      case validPath if validPath.startsWith(this.canonicalPath + JFile.separator) =>
-        destination.createIfNotExists(asDirectory, createParents)(attributes, linkOptions)
-      case _ => throw new IOException("File is outside directory.")
-    }
+    if (destination.isChildOf(this)) destination.createIfNotExists(asDirectory, createParents)(attributes, linkOptions)
+    else throw new IOException("File is outside target directory")
   }
 
   /**

--- a/core/src/test/scala/better/files/FileSpec.scala
+++ b/core/src/test/scala/better/files/FileSpec.scala
@@ -1,5 +1,6 @@
 package better.files
 
+import java.io.IOException
 import java.nio.file.{FileAlreadyExistsException, FileSystems, Files => JFiles}
 
 import better.files.Dsl._
@@ -238,6 +239,9 @@ class FileSpec extends CommonSpec {
     fa isParentOf fa shouldBe false
     b2 isChildOf b2 shouldBe false
     b2 isChildOf b2.parent shouldBe true
+    an[IOException] shouldBe thrownBy {
+      testRoot.createChild("../../invalidFile.txt")
+    }
     root.parent shouldBe null
   }
 


### PR DESCRIPTION
To fix #256.
I added validation in ``createChild`` method. 
If a `File` created by `createChild` method is outside target directory, it throws IOException.

Besides, I found canonicalPath method using `java.io.File.getAbsolutePath`, so I replaced it with `java.io.File.getCanonicalPath`