### PR TITLE
Fix Akka File Watcher example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,8 @@ val watcher: ActorRef = (home/"Downloads").newWatcher(recursive = true)
 
 // register partial function for an event
 watcher ! on(EventType.ENTRY_DELETE) {
-  case file if file.isDirectory => println(s"$file got deleted")
+  case file if file.isDirectory => println(s"directory $file got deleted")
+  case file                     => println(s"$file got deleted")
 }
 
 // watch for multiple events

--- a/README.md
+++ b/README.md
@@ -756,8 +756,8 @@ watcher ! on(EventType.ENTRY_DELETE) {
 
 // watch for multiple events
 watcher ! when(events = EventType.ENTRY_CREATE, EventType.ENTRY_MODIFY) {
-  case (EventType.ENTRY_CREATE, file, count) => println(s"$file got created")
-  case (EventType.ENTRY_MODIFY, file, count) => println(s"$file got modified $count times")
+  case (EventType.ENTRY_CREATE, file) => println(s"$file got created")
+  case (EventType.ENTRY_MODIFY, file) => println(s"$file got modified")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -743,7 +743,9 @@ See: https://github.com/gmethvin/directory-watcher#better-files-integration-scal
 based on [Akka actors](http://doc.akka.io/docs/akka/snapshot/scala/actors.html) that supports dynamic dispatches:
  ```scala
 import akka.actor.{ActorRef, ActorSystem}
-import better.files._, FileWatcher._
+import better.files.File.home
+import better.files.FileWatcher._
+import java.nio.file.{StandardWatchEventKinds => EventType}
 
 implicit val system = ActorSystem("mySystem")
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To use the [Akka based file monitor](akka), also add this:
 ```scala
 libraryDependencies ++= Seq(
   "com.github.pathikrit"  %% "better-files-akka"  % version,
-  "com.typesafe.akka"     %% "akka-actor"         % "2.5.13"
+  "com.typesafe.akka"     %% "akka-actor"         % "2.6.13"
 )
 ```
 Latest `version`: [![Scaladex][scaladexImg]][scaladexLink]


### PR DESCRIPTION
I could have bumped the Akka dependency also to `2.6.13` but then it would fail for Scala 2.11 which better files still supports. Instead, I opted for the last Akka version supporting 2.11

Happy to rebase if PR is too granular