### PR TITLE
Fix #478: NoSuchFileException thrown when calling size on broken symlink

### DIFF
--- a/core/src/main/scala/better/files/File.scala
+++ b/core/src/main/scala/better/files/File.scala
@@ -853,6 +853,7 @@ class File private (val path: Path)(implicit val fileSystem: FileSystem = path.g
           Files.size(f.path)
         } catch {
           case _: FileNotFoundException if returnZeroIfMissing => 0L
+          case _: NoSuchFileException   if returnZeroIfMissing => 0L
         }
       })
       .sum


### PR DESCRIPTION
The goal of this PR is to also catch NoSuchFileException which is thrown when calling size function on a broken symlink (see  #478  for more details)

Feel free to take it over or discard it if not necessary, and I welcome any feedback!